### PR TITLE
#2 Persistence Context

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,13 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="687f9fee-fbed-48ef-aba6-5cbc6c44bccf" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
+    <list default="true" id="687f9fee-fbed-48ef-aba6-5cbc6c44bccf" name="Changes" comment="#1 JPA Setting, Basic">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/pom.xml" beforeDir="false" afterPath="$PROJECT_DIR$/pom.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/META-INF/persistence.xml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/META-INF/persistence.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -79,8 +75,16 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1659082697673</updated>
-      <workItem from="1659082700455" duration="5305000" />
+      <workItem from="1659082700455" duration="8201000" />
     </task>
+    <task id="LOCAL-00001" summary="#1 JPA Setting, Basic">
+      <created>1659088165070</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1659088165070</updated>
+    </task>
+    <option name="localTasksCounter" value="2" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -96,5 +100,9 @@
         </entry>
       </map>
     </option>
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="#1 JPA Setting, Basic" />
+    <option name="LAST_COMMIT_MESSAGE" value="#1 JPA Setting, Basic" />
   </component>
 </project>

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -12,14 +12,20 @@ public class JpaMain {
         tx.begin();
 
         try {
-//            Member findMember = em.find(Member.class, 1L);
+            // 비영속
+            Member member = new Member();
+            member.setId(101L);
+            member.setName("HelloJPA");
 
-            List<Member> result = em.createQuery("select m from Member as m", Member.class)
-                    .getResultList();
+            // 영속
+            System.out.println("=== BEFORE ===");
+            em.persist(member);
+            System.out.println("=== AFTER ===");
 
-            for (Member member : result) {
-                System.out.println("member.name = " + member.getName());
-            }
+            Member findMember1 = em.find(Member.class, 100L);
+            Member findMember2 = em.find(Member.class, 100L);
+
+            System.out.println(findMember1 == findMember2);
 
             tx.commit();
         } catch (Exception e) {


### PR DESCRIPTION
JPA 에서 가장 중요한 두가지가 있다.
1. ORM 객체 - 관계형 DB의 Mapping
2. 영속성 컨텍스트 ( Persistence Context ) - 엔티티를 영구 저장하는 환경
Persistence Context란 EntityManager 내부에 존재하는 것 같다. 강의에서는 동일하지는 않지만 지금은 같다고 보자고 했다.
지금은 J2SE 환경에서 하고 있으므로 EntityManager와 PersistenceContext가 1:1 관계에 있다.
하지만 Spring framework 같은 Container 환경에서는 ( J2EE ) N:1 관계에 있다.

객체를 DB에 저장하기 위해서 지금까지는 em.persist(member); 라고 하였다.
하지만 실제 내부에서는 바로 DB에 쿼리를 날리지 않는다. 일단 Persistence Context 내부 1차캐시공간에 저장
즉, persist 나 find 를 사용할 경우 일단 1차캐시공간에 저장되어 영속된다. - managed 상태
Persistence Context와 객체를 다시 분리하려면 em.detach(member) 를 사용하면 된다.
아예 관계를 끊으려면 em.remove(member) 를 사용하면 된다. 

이런 Persistence Context의 이점은 
1. 1차 캐시
2. 동일성 보장
3. 트랜잭션을 지원하는 쓰기 지연
4. 변경 감지
5. 지연 로딩 이 있다.

1-. 1차 캐시
예를 들어 em.persist(member) 이후 em.find(Member.class, "100L") 이라고 할 경우
find 에서 아직 DB와 통신 전에 먼저 1차 캐시를 조회해서 일치하면 그대로 반환한다. 쿼리를 날리지 않음
그리고 persist에 대한 쿼리는 커밋을 할 때 날림.
두번째 예로는 똑같은 멤버를 여러번 find 하는 경우, 멤버가 1차 캐시에 존재하지 않으면 
첫 find에서만 DB를 조회해서 일단 1차캐시에 저장한다. 그리고 이후의 find들은 쿼리를 날리지 않고 1차 캐시에 저장된 값을 반환받는다.
** 1차 캐시는 트랜잭션 단위로 존재하기때문에 트랜잭션이 끝날 때 저장된 값들도 사라진다. 1차 캐시를 통해 얻는 이득은 미미하다는 말이다. 공용 트랜잭션에서 존재하는 개념이 아님.

2-. 동일성 보장
동일 트랜잭션 내에서는 같은 member 에 대해서 동일성을 보장한다.
