### PR TITLE
#3 Persistence Context - 2

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,6 +7,8 @@
     <list default="true" id="687f9fee-fbed-48ef-aba6-5cbc6c44bccf" name="Changes" comment="#1 JPA Setting, Basic">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/META-INF/persistence.xml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/META-INF/persistence.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -32,21 +34,21 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "WebServerToolWindowFactoryState": "false",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "project.structure.last.edited": "Project",
-    "project.structure.proportion": "0.0",
-    "project.structure.side.proportion": "0.0",
-    "settings.editor.selected.configurable": "project.propDebugger"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.0&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;project.propDebugger&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager">
     <configuration name="JpaMain" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="hellojpa.JpaMain" />

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -12,20 +12,16 @@ public class JpaMain {
         tx.begin();
 
         try {
-            // 비영속
-            Member member = new Member();
-            member.setId(101L);
-            member.setName("HelloJPA");
+//            Member member1 = new Member(150L, "A");
+//            Member member2 = new Member(160L, "B");
+//
+//            em.persist(member1);
+//            em.persist(member2);
 
-            // 영속
-            System.out.println("=== BEFORE ===");
-            em.persist(member);
-            System.out.println("=== AFTER ===");
+            Member findMember = em.find(Member.class, 150L);
+            findMember.setName("Luffy");
 
-            Member findMember1 = em.find(Member.class, 100L);
-            Member findMember2 = em.find(Member.class, 100L);
-
-            System.out.println(findMember1 == findMember2);
+            System.out.println("======================");
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -10,6 +10,12 @@ public class Member {
     private Long id;
     private String name;
 
+    public Member() {}
+    public Member(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -15,6 +15,7 @@
             <property name="hibernate.show_sql" value="true"/>
             <property name="hibernate.format_sql" value="true"/>
             <property name="hibernate.use_sql_comments" value="true"/>
+            <property name="hibernate.jdbc.batch_size" value="10"/>
             <!--<property name="hibernate.hbm2ddl.auto" value="create" />-->
         </properties>
     </persistence-unit>


### PR DESCRIPTION
Persistence Context 의 이점을 이어서 쓰겠다.
3. 쓰기 지연
한 트랜잭션 내에서 여러 개의 em.persist(member) 가 존재한다고 가정하자. 그 때 JPA는 Persistence Context 내부의 1차캐시와 쓰기지연 SQL 저장소에 쿼리를 만들어 놓는다. 쿼리를 그때 그때 DB에 날리는게 아니라 만들어 놓기만 한다. 그리고 transaction.commit()이 보이면 그 직전에 쿼리를 DB에 날린다.
이는 실무에서 드라마틱한 도움이 되지는 않는다고 한다. 한 트랜잭션내에서 최적화를 해보았자 성능이 어마어마하게 빨라지는 것은 아니기에. persistence.xml에서 몇개의 쿼리를 한번에 보낼지 jdbc batch를 이용해 조절 가능.
4. 변경 감지 ( Dirty Checking )
이건 꽤나 의미가 있다. 우리가 DB에서 엔티티를 조회해서 받은 후 엔티티 내부의 값들을 바꾸었을 때, 그 엔티티를 다시 DB에 개발자가 직접 쿼리를 날릴 필요가 없다. 조회해서 엔티티를 받을 때 Persistence Context 내부 1차캐시에 스냅샷 ( DB에서 받았을때 바로 저장 ) 이 저장된다. JPA는 현재 엔티티와 스냅샷을 비교하여 변경을 감지하여 미리 쓰기지연 SQL 저장소에 update 쿼리를 알아서 만들어 놓는다. 그리고 쓰기 지연과 마찬가지로 commit 직전에 DB에 쿼리를 날린다.
