### PR TITLE
#4 flush

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,8 +7,6 @@
     <list default="true" id="687f9fee-fbed-48ef-aba6-5cbc6c44bccf" name="Changes" comment="#1 JPA Setting, Basic">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/META-INF/persistence.xml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/META-INF/persistence.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -12,14 +12,10 @@ public class JpaMain {
         tx.begin();
 
         try {
-//            Member member1 = new Member(150L, "A");
-//            Member member2 = new Member(160L, "B");
-//
-//            em.persist(member1);
-//            em.persist(member2);
+            Member member = new Member(200L, "member200");
 
-            Member findMember = em.find(Member.class, 150L);
-            findMember.setName("Luffy");
+            em.persist(member);
+            em.flush();
 
             System.out.println("======================");
 


### PR DESCRIPTION
flush에 대한 설명과 함께 #3 의 오개념을 바로잡겠다.
플러시 ( Flush ) - Persistence Context 의 변경내용을 DB에 반영.

** em.persist(member) 의 경우에는 바로 쓰기 지연 SQL 저장소에 등록되는게 맞다.
** 하지만 조회된 값을 변경했을 때는 변경 시점에 즉시 쓰기 지연 SQL 저장소에 등록되는게 아니다.

플러시가 발생하면
1. 변경된 값이 있는지 감지한다. -> 여기서 변경된 엔티티가 있을 경우 쓰기 지연 SQL 저장소에 쿼리가 등록.
2. 쓰기 지연 SQL 저장소의 쿼리들을 DB에 전송 ( insert, update, delete 쿼리들 )

플러시를 발생시키는 방법은 세가지가 있다.
 1. em.flush()로 강제로 직접 호출을 하는 방법이다. 일반적인 경우에 사용하지 않고, 특별히 내가 먼저 DB에 엔티티를 넣고 조회를 해보고 싶을 때 사용한다.
 2. 트랜잭션 커밋. 앞에서 계속 말한 가장 흔한 경우이다. 커밋 직전에 자동으로 플러시를 호출한다.
 3. JPQL 쿼리 실행. 이건 JPA에서 혼란을 배제하기 위해 표준을 이렇게 했다고 한다. 트랜잭션 커밋과 마찬가지로 쿼리 실행 전에 플러시를 자동으로 호출한다.
+ em.setFlushMode(FlushModeType.COMMIT) -> 커밋할 때만 플러시를 호출하게 수정할 수 있다. 웬만하면 안한다.

*** 플러시는 그 이름 때문에 오개념이 생길 수 있다. 
플러시는 Persistence Context를 비우는 것이 아니라 쓰기 지연 SQL 저장소에 있는 쿼리들만 DB로 날리는 것.
즉, 1차 캐시에 저장된 값들은 지워지지 않는다.

플러시는 Persistence Context의 변경내용을 DB에 동기화 하는것. 중요한 것은 트랜잭션이라는 단위의 존재.
트랜잭션이라는 작업 단위가 존재함으로써 커밋 직전에 동기화 하는 것이 가능해짐.