### PR TITLE
#6 준영속

### DIFF
--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -12,10 +12,12 @@ public class JpaMain {
         tx.begin();
 
         try {
-            Member member = new Member(200L, "member200");
+            Member member1 = em.find(Member.class, 150L);
+            member1.setName("ZZZZ");
 
-            em.persist(member);
-            em.flush();
+            em.clear();
+
+            Member member2 = em.find(Member.class, 150L);
 
             System.out.println("======================");
 


### PR DESCRIPTION
준영속이란, 영속 상태에 있는 엔티티를 영속성 컨텍스트에서 분리하는 것이다.

먼저 엔티티가 영속 상태에 있으려면 persist나 find를 했을 것이다. 

엔티티를 준영속 상태로 바꾸는 방법은 세가지가 있다.
1. em.detach(entity)
2. em.clear()
3. em.close() -> 이건 이 이후의 쿼리도 안날아간다. 아예 영속성 컨텍스트를 종료해버림.

준영속 상태에 있는 엔티티는 더 이상 JPA가 관리하지 않기 때문에 엔티티 변경이 있더라도 쿼리가 만들어지지 않는다.

아직은 이걸 사용하지는 않을 거다. 이론적으로 이런게 있다는 것만 알아두자.