### PR TITLE
#1 Entity, Table Mapping 과 DB 스키마 자동 생성

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,6 +7,8 @@
     <list default="true" id="687f9fee-fbed-48ef-aba6-5cbc6c44bccf" name="Changes" comment="#1 JPA Setting, Basic">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/META-INF/persistence.xml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/META-INF/persistence.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -12,10 +12,10 @@ public class JpaMain {
         tx.begin();
 
         try {
+//            em.persist(new Member(150L, "haha"));
             Member member1 = em.find(Member.class, 150L);
             member1.setName("ZZZZ");
 
-            em.clear();
 
             Member member2 = em.find(Member.class, 150L);
 

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -1,13 +1,17 @@
 package hellojpa;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 @Entity
+//@Table(name = "Member")
 public class Member {
 
     @Id
     private Long id;
+    @Column(unique = true, length = 10)
     private String name;
 
     public Member() {}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -16,7 +16,7 @@
             <property name="hibernate.format_sql" value="true"/>
             <property name="hibernate.use_sql_comments" value="true"/>
             <property name="hibernate.jdbc.batch_size" value="10"/>
-            <!--<property name="hibernate.hbm2ddl.auto" value="create" />-->
+            <property name="hibernate.hbm2ddl.auto" value="create" />
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
1. JPA를 이용하여 DB에 저장하고자 하는 객체 class에 @Entity를 붙여주어야 JPA가 관리한다.

** 주의
기본 생성자 필수 ( 파라미터가 없는 생성자 )
final class, enum, interface, inner class 사용 불가
저장할 필드에도 final 사용 불가

어떻게 보면 당연한거다. 값을 바꾸어 저장할 테니 final으로 선언하지 말라는 것이다.

@Entity(name="") 으로 JPA에서 사용할 엔티티 이름을 지정할 수도 있다. 이 기능은 가급적 사용하지 않는다.
기본값으로는 class 이름이 그대로 사용되는데, 부득이하게 다른 package에 JPA가 관리하는 같은 이름의 class가 
존재할 경우에만 JPA가 이를 구분할 수 있게 이름을 다르게 설정해준다.

@Table(name="") 으로 엔티티와 매핑될 DB의 table을 지정할 수 있다. 이 기능은 실무에서 쓰고 있을 수도 있다.
기본값으로는 엔티티 class의 이름과 동일한 table을 찾는다. 하지만 내 class 이름은 member이고, 매핑할 DB table 이름은 user일 경우에 이 기능이 필요하다.

2. 데이터베이스 스키마 자동 생성

스키마란, 데이터베이스의 구조를 설계? 하는 것이다. JPA 에서는 이를 자동으로 생성할 수도 있다.
DDL 이란, 데이터베이스의 구조를 정의하는데 사용되는 명령어들이다.
DDL을 자동으로 작성하여 결국 스키마를 생성한다고 볼 수 있는거 같다.

persistence.xml에 <property name="hibernate.hbm2ddl.auto" value="create" /> 를 추가함으로써 구현한다.

기존에는 DB에 객체를 매핑하여 저장하기 위해서는 객체에 맞게 DB에 개발자가 직접 sql 문을 작성하여 구조를 만들어 주었다.
하지만 JPA가 @Entity 가 붙은 class를 보고 구조를 알아서 작성하여 DB에 쿼리를 보낸다.

DDL을 애플리케이션 실행 시점에 자동 생성하고, 테이블 중심에서 객체 중심 코드로 바뀌었다고 볼 수 있다. 앞에서 언급했던 dialect 속성에서 방언을 바꾸면 DB에 맞는 적절한 DDL을 생성한다.

value 에 들어가는 속성에는 create, create-drop, update, validate, none 이 있다.

** 주의
운영 장비에는 절대 create, create-drop, update 사용하면 안된다.
create와 create-drop 은 기본적으로 시작할 때 table을 drop하고 시작하기 때문에 기존의 DB가 날아가 버린다.
update는 여러 사용자가 있을 경우 서비스가 멈출 수 있다고 한다.
실제 운영서버는 validate 혹은 대부분 none을 쓴다.

@Column(unique = true, length = 10) 이렇게 제약조건을 추가 할 수도 있다.

*** DDL의 자동 생성 기능은 애플리케이션 실행 시점에 생성되기 때문에 JPA의 실행 로직에는 영향을 주지 않는다.