### PR TITLE
#3 기본 키 (Primary Key) Mapping

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="687f9fee-fbed-48ef-aba6-5cbc6c44bccf" name="Changes" comment="#1 JPA Setting, Basic">
-      <change afterPath="$PROJECT_DIR$/src/main/java/hellojpa/RoleType.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" afterDir="false" />
     </list>
@@ -35,21 +33,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.0&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;project.propDebugger&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "last_opened_file_path": "/Users/mintae/Study/ex1-hello-jpa",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "project.structure.last.edited": "Project",
+    "project.structure.proportion": "0.0",
+    "project.structure.side.proportion": "0.0",
+    "settings.editor.selected.configurable": "project.propDebugger"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
       <recent name="hellojpa" />
@@ -84,6 +83,7 @@
       <option name="presentableId" value="Default" />
       <updated>1659082697673</updated>
       <workItem from="1659082700455" duration="8201000" />
+      <workItem from="1659610820996" duration="313000" />
     </task>
     <task id="LOCAL-00001" summary="#1 JPA Setting, Basic">
       <created>1659088165070</created>

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -13,13 +13,19 @@ public class JpaMain {
 
         try {
 
-            Member member = new Member();
+            Member member1 = new Member();
+            Member member2 = new Member();
+            Member member3 = new Member();
 
-            member.setId(3L);
-            member.setUsername("C");
-            member.setRoleType(RoleType.ADMIN);
+            member1.setUsername("A");
+            member2.setUsername("B");
+            member3.setUsername("C");
 
-            em.persist(member);
+            System.out.println("=================");
+            em.persist(member1);
+            em.persist(member2);
+            em.persist(member3);
+            System.out.println("=================");
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -6,58 +6,24 @@ import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
-//@Table(name = "Member")
+@SequenceGenerator
+        (name = "MEMBER_SEQ_GENERATOR",
+        sequenceName = "MEMBER_SEQ",
+        initialValue = 1, allocationSize = 50)
 public class Member {
 
     @Id
+    @GeneratedValue
+            (strategy = GenerationType.SEQUENCE,
+            generator = "MEMBER_SEQ_GENERATOR")
     private Long id;
 
     @Column(name = "name")
     private String username;
 
-    private Integer age;
-
-    @Enumerated(EnumType.STRING)
-    private RoleType roleType;
-
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date createdDate;
-
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date lastModifiedDate;
-
-    private LocalDate testLocalDate;
-    private LocalDateTime testLocalDateTime;
-    @Lob
-    private String description;
-
     public Member() {}
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public void setUsername(String username) {
         this.username = username;
-    }
-
-    public void setAge(Integer age) {
-        this.age = age;
-    }
-
-    public void setRoleType(RoleType roleType) {
-        this.roleType = roleType;
-    }
-
-    public void setCreatedDate(Date createdDate) {
-        this.createdDate = createdDate;
-    }
-
-    public void setLastModifiedDate(Date lastModifiedDate) {
-        this.lastModifiedDate = lastModifiedDate;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
     }
 }


### PR DESCRIPTION
앞의 예제까지는 기본 키를 직접 할당하여 DB에 매핑하였다. 하지만 실무에서는 ID, 즉 PK값을 DB에게 할당하도록 한다.

세 가지 방법으로 구현이 가능하다.

1.  IDENTITY - My SQL
 IDENTITY 전략은 간단하다. @Id 옆에 @GeneratedValue(strategy = GenerationType.IDENTITY) 해주면 끝.
이 방법은 MySQL DB에서 사용 한다. DB가 MySQL의 AUTO_INCREMENT 를 사용하여 PK를 내부에서 구현한다.

** JPA는 커밋 직전에 DB에 쿼리를 보낸다고 했었다. 그런데, 이렇게 되면 em.persist(member) 를 할 때 Persistence Context 내부 1차 캐시 저장소에 저장할 ID 값을 아직 모른다. ( 왜? 아직 DB에 안넣어서 모르니까 )
그래서 JPA는 IDENTITY 를 보고 em.persist 할 때 바로 DB에 쿼리를 보내서 ID 값을 받아온다. 

2. SEQUENCE - ORACLE, H2
 SEQUENCE 전략은 DB의 SEQUENCE 오브젝트를 사용한다. @Entity 어노테이션과 함께 @SEQUENCEGENERATOR 어노테이션으로 generator의 이름, 시퀀스의 이름, initial val, allocationSize를 정해주면 된다. 그리고 @Id 와 함께 @GeneratedValue(Strategy=GenerationType.SEQUENCE, generator= 내가 설정한 이름) 을 입력해 주면 된다. initial value는 default 1 이고, allocation Size default 값은 50 이다.

** allocation Size는 최적화와 관련되어 있다. size가 1일 경우에는 매번 네트워크 통신을 해서 값을 받아와야 해서 성능이 떨어진다는 단점이 있다. size가 매우 크면 그만큼 받아올 일이 적겠지만, 통상적으로 50이면 충분하다고 한다. 처음에 1값을 주어야 하기에 통신이 2번된다는 것을 주의하자. -49 -> 1 -> 51 이렇게 불러온다. 그 이후에는 50까지 네트워크 통신 없이 Memory에서 값을 꺼내서 쓴다. 

3. TABLE
 TABLE 전략은 Key 생성용 테이블을 직접 만들어서 SEQUENCE 전략을 흉내내는 전략이다. 장점으로는 모든 DB에 적용이 가능하다. 단점은 성능이 떨어진다. SEQUENCE 전략과 문법도 비슷하다. name, table, pkColumnValue, allocationSize를 정해주면 된다.

기본 키의 제약 조건은 null이 아니어야하고, 유일하며, 불변해야 한다.
먼 미래까지 이 조건을 만족하는 자연키 ( ex 주민등록번호 ) 는 없다고 봐도 무방하다. 대체키를 사용하자.
권장 : Long 형 + 대체키 + 키 생성전략