### PR TITLE
#1 단방향 연관관계 (객체 지향 모델링)

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="687f9fee-fbed-48ef-aba6-5cbc6c44bccf" name="Changes" comment="#3 기본 키 (Primary Key) Mapping">
-      <change afterPath="$PROJECT_DIR$/src/main/java/hellojpa/Team.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" afterDir="false" />

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -18,12 +18,19 @@ public class JpaMain {
 
             Member member = new Member();
             member.setUsername("member1");
-            member.setTeamId(team.getId());
+            member.setTeam(team);
             em.persist(member);
 
+
             Member findMember = em.find(Member.class, member.getId());
-            Long findTeamId = findMember.getTeamId();
-            Team findTeam = em.find(Team.class, findTeamId);
+            findMember.getTeam();
+
+
+            Team team2 = new Team();
+            team2.setName("B");
+            em.persist(team2);
+            member.setTeam(team2);
+            em.persist(member);
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -15,8 +15,17 @@ public class Member {
     @Column(name = "USERNAME")
     private String username;
 
-    @Column(name = "TEAM_ID")
-    private Long teamId;
+    @ManyToOne
+    @JoinColumn(name = "TEAM_ID")
+    private Team team;
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
+    }
 
     public Long getId() {
         return id;
@@ -26,16 +35,8 @@ public class Member {
         this.id = id;
     }
 
-    public void setTeamId(Long teamId) {
-        this.teamId = teamId;
-    }
-
     public String getUsername() {
         return username;
-    }
-
-    public Long getTeamId() {
-        return teamId;
     }
 
     public Member() {}


### PR DESCRIPTION
관계형 DB에는 외래 키(Foreign Key) 라는 연관 관계가 있고, 객체에는 참조라는 연관 관계가 있다.
이 연관 관계를 JPA를 통해 매핑해 줄 수 있다. 코드는 객체 지향적으로 작성한 후, 이번 예제의 경우 Member와 Team 중 N은 Member이기 때문에 Member가 연관 관계의 주인이 된다. 따라서 Member class 내부에 private Team team을 두고 @ManyToOne, @JoinColumn(name="TEAM_ID") 라고 하면 JPA가 알아서 객체와 관계형 DB의 연관 관계를 매핑해준다.