### PR TITLE
#2 양방향 연관관계 매핑

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,7 +7,7 @@
     <list default="true" id="687f9fee-fbed-48ef-aba6-5cbc6c44bccf" name="Changes" comment="#3 기본 키 (Primary Key) Mapping">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/JpaMain.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/Member.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/hellojpa/Team.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/hellojpa/Team.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -89,6 +89,7 @@
       <workItem from="1659679147715" duration="5000" />
       <workItem from="1659680001918" duration="50000" />
       <workItem from="1659795171269" duration="1178000" />
+      <workItem from="1659879828936" duration="2073000" />
     </task>
     <task id="LOCAL-00001" summary="#1 JPA Setting, Basic">
       <created>1659088165070</created>

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -21,16 +21,16 @@ public class JpaMain {
             member.setTeam(team);
             em.persist(member);
 
+            em.flush();
+            em.clear();
 
             Member findMember = em.find(Member.class, member.getId());
-            findMember.getTeam();
+            System.out.println(findMember.getUsername());
+            List<Member> members = findMember.getTeam().getMembers();
+            for (Member member1 : members) {
+                System.out.println(member1.getUsername());
+            }
 
-
-            Team team2 = new Team();
-            team2.setName("B");
-            em.persist(team2);
-            member.setTeam(team2);
-            em.persist(member);
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Team.java
+++ b/src/main/java/hellojpa/Team.java
@@ -1,9 +1,8 @@
 package hellojpa;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Team {
@@ -15,8 +14,18 @@ public class Team {
     @Column(name = "TEAM_NAME")
     private String name;
 
+    @OneToMany(mappedBy = "team")
+    private List<Member> members = new ArrayList<Member>();
     public Long getId() {
         return id;
+    }
+
+    public List<Member> getMembers() {
+        return members;
+    }
+
+    public void setMembers(List<Member> members) {
+        this.members = members;
     }
 
     public String getName() {


### PR DESCRIPTION
이전의 코드에서는 단방향 연관관계를 매핑했었다. 

Member class에 TEAM을 만들고 @ManyToOne, @JoinColumn(name="TEAM_ID") 으로 DB의 Foreign Key인 TEAM_ID와 매핑을 하였다. 하지만 이렇게 되면 아직 DB의 연관관계와 객체의 연관관계가 일치하지 않는다.

이게 무슨 말이냐 하면, DB상에서는 FK와 PK를 이용해서 얼마든지 Member에서 Team으로, Team에서 Member로 Join이 가능하다. 즉, 양방향으로 연관관계가 형성되어 있다.

따라서, 이 연관 관계를 객체에서도 유지하려면, Team에도 List<Member> Members를 두어 @OneToMany(mappedby="team") 어노테이션을 사용해 양방향으로 참조가 가능해야 한다. 그러면 또 새로운 문제가 생긴다. DB의 MEMBER Table에 있는 TEAM_ID는 member가 바뀔 때 바뀌어야 하는건지, Team이 바뀔 때 바뀌어야 하는건지, 둘 다 인지 에 대한 문제가 생긴다. 

이 문제에 대한 기준을 세우기 위해, 객체의 연관관계에서 연관관계의 주인을 지정해야 한다. 그리고 주인은 항상 N(다수)인 쪽으로 정한다. DB 상에서 항상 다수인 쪽이 FK를 가지고 있기 때문이다. 
( DB상에서 다수인 쪽이 FK를 가짐 -> FK를 가진 쪽을 주인으로 지정함. ) 따라서 다수인 쪽이 주인.

** 주의
그리고 값의 변경은 주인으로 지정한 곳에서만 이루어진다. 반대쪽에서는 값을 넣어 봤자 DB에 반영이 안된다. 

주인이 아닌 쪽에서는 값을 조회하는 것만 가능하다. 그리고 조회하는 것도 DB에서 JPA가 제공하는 객체를 받아와야 하기 때문에 em.flush(); em.clear(); 이후에 객체를 조회해서 받아야 findMember.getTeam().getMembers()와 같이 주인이 아닌 클래스에서 주인 클래스로의 올바른 참조가 가능해진다.

** em.persist(member) 시점에 1차 캐시에는 Members에 대한 값은 저장되지 않는다. 그도 당연한게 우리는 아직 그에 대한 값을 넣어준 적이 없다. 그래서 반드시 DB에서 받아온 JPA가 제공한 객체를 받아야 null 값이 아닌 제대로 된 값이 나온다.