### PR TITLE
#5 양방향 연관 관계2 - 주의할 점

### DIFF
--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -18,18 +18,23 @@ public class JpaMain {
 
             Member member = new Member();
             member.setUsername("member1");
-            member.setTeam(team);
+            //member.setTeam(team);
             em.persist(member);
 
-            em.flush();
-            em.clear();
+            team.addMember(member);
 
-            Member findMember = em.find(Member.class, member.getId());
-            System.out.println(findMember.getUsername());
-            List<Member> members = findMember.getTeam().getMembers();
-            for (Member member1 : members) {
-                System.out.println(member1.getUsername());
+//            team.getMembers().add(member);
+//            em.flush();
+//            em.clear();
+
+            Team findTeam = em.find(Team.class, member.getTeam().getId());
+            List<Member> members = findTeam.getMembers();
+
+            System.out.println("====================");
+            for (Member m : members) {
+                System.out.println("member m = " + m.getUsername());
             }
+            System.out.println("====================");
 
 
             tx.commit();

--- a/src/main/java/hellojpa/Team.java
+++ b/src/main/java/hellojpa/Team.java
@@ -16,6 +16,11 @@ public class Team {
 
     @OneToMany(mappedBy = "team")
     private List<Member> members = new ArrayList<Member>();
+
+    public void addMember(Member member) {
+        member.setTeam(this);
+        members.add(member);
+    }
     public Long getId() {
         return id;
     }


### PR DESCRIPTION
저번 예제까지의 양방향 연관 관계에서는 JPA가 연관 관계를 인식할 수 있도록 객체 지향적으로 코드를 작성하고 어노테이션들을 추가해 주었다. 그리고 연관 관계의 주인(다수)인 class에서 FK와 관련된 값을 변경한 것만 DB에 반영이 된다고 하였다. 하지만 이렇게 되면 몇 가지 문제가 발생할 수 있다.

이전의 예제에서는 Member.setTeam() 으로 member에서만 값을 변경해주고 Team.getMembers.add()는 해주지 않았다. 물론 해주지 않아도 JPA는 잘 알아 듣고 DB에 변경을 반영한다. 하지만 em.flush(), em.clear() 하지 않은 상태에서 조회할 경우, 1차 캐시에 저장된 객체를 받아서 사용하게 되어 team.getMembers()가 null인 문제가 발생하게 된다. 따라서 양방향 연관 관계를 할 경우에는 순수 객체 관계를 고려해서 양쪽에서 값을 넣어주는 것이 바람직하다.

그리고 여기서 약간 실무에서 사용하는 기술이 들어가면, 연관 관계 편의 메소드를 생성하자. 결국 우리는 연관 관계의 주인인 Member.setTeam(team)을 해주기만 하면 된다. 어떻게 그것을 구현할 지는 개발자의 선택이다. 이게 무슨 말이냐 하면, Team Entity에 addMemeber() 라는 편의 메소드를 구현해서 그 내부에서 양쪽에 값을 넣어주는 처리를 하는 것이다. 

*** 연관 관계 편의 메서드는 한쪽에만 생성하는 것이 바람직하다. 어느쪽에 할 지는 비즈니스 로직에 따라 선택.

** 양방향 매핑시에 무한 루프를 조심하자. toString()을 불러올 경우 Member에서는 Team을, Team에서는 다시 Members를 계속해서 출력하는 문제가 생길 수 있다. lombok에서 toString()을 자동으로 모든 필드를 출력하게 되어있기 때문에 toString()을 하고 싶다면 따로 구현을 해주어야 한다. JSON 생성 라이브러리에서도 무한 루프 문제가 발생할 수 있다고 한다. Controller에서 Entity를 반환하지 않으면 대부분의 문제가 해결 된다고 한다. 아직은 무슨 말인지 잘 모르겠다.

양방향 매핑을 정리해보자면,
단방향 매핑만으로도 이미 연관관계 매핑은 끝난거다. DB의 연관 관계와 매핑을 이미 완료한 것이다. 양방향 매핑은 반대 방향으로의 조회 기능이 추가된 것 뿐이다. 즉, 객체를 기준으로 보면 단방향 연관 관계가 바람직하다. 양방향 관계가 많아질수록 신경 쓸 게 많아진다. 하지만 실무를 하다보면 JPQL에서 역방향으로 탐색할 일이 많다고 한다.

따라서 코드를 작성할 때, 일단 단방향 매핑으로 끝낸다는 생각으로 매핑을 하고, 코드를 발전시켜 나가는데 있어 역방향 조회가 필요하다면 그 때 엔티티만 살짝 수정해주면 된다.

+ 추가로 다시 강조하지만, 연관 관계의 주인은 비즈니스 로직을 기준으로 선택하는 것이 아니라 외래 키의 위치를 기준으로 정해야 한다.