### PR TITLE
#6 일대다(1:N) 연관관계 매핑

### DIFF
--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -12,30 +12,15 @@ public class JpaMain {
         tx.begin();
 
         try {
-            Team team = new Team();
-            team.setName("A");
-            em.persist(team);
-
             Member member = new Member();
-            member.setUsername("member1");
-            //member.setTeam(team);
+            member.setUsername("A");
             em.persist(member);
 
-            team.addMember(member);
+            Team team = new Team();
+            team.setName("teamA");
+            team.getMembers().add(member);
 
-//            team.getMembers().add(member);
-//            em.flush();
-//            em.clear();
-
-            Team findTeam = em.find(Team.class, member.getTeam().getId());
-            List<Member> members = findTeam.getMembers();
-
-            System.out.println("====================");
-            for (Member m : members) {
-                System.out.println("member m = " + m.getUsername());
-            }
-            System.out.println("====================");
-
+            em.persist(team);
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -15,18 +15,6 @@ public class Member {
     @Column(name = "USERNAME")
     private String username;
 
-    @ManyToOne
-    @JoinColumn(name = "TEAM_ID")
-    private Team team;
-
-    public Team getTeam() {
-        return team;
-    }
-
-    public void setTeam(Team team) {
-        this.team = team;
-    }
-
     public Long getId() {
         return id;
     }

--- a/src/main/java/hellojpa/Team.java
+++ b/src/main/java/hellojpa/Team.java
@@ -14,16 +14,9 @@ public class Team {
     @Column(name = "TEAM_NAME")
     private String name;
 
-    @OneToMany(mappedBy = "team")
+    @OneToMany
+    @JoinColumn(name = "TEAM_ID")
     private List<Member> members = new ArrayList<Member>();
-
-    public void addMember(Member member) {
-        member.setTeam(this);
-        members.add(member);
-    }
-    public Long getId() {
-        return id;
-    }
 
     public List<Member> getMembers() {
         return members;


### PR DESCRIPTION
지금까지는 계속해서 다대일(N:1) 연관관계 매핑에 대해서 공부했다. 일대다와 다대일의 차이는 연관관계의 주인이 누구인가의 차이이다. 앞에서의 설명이 미흡해서 이번 설명에서 총 정리를 하겠다.

DB Table상에서는 반드시 다(N)인 쪽이 외래 키(FK)를 관리한다. 하지만 객체 상에서 외래 키를 누구와 매핑할지는 개발자가 선택할 수 있다. 하지만 권장은 객체 상에서도 다수인 쪽이 연관관계의 주인인 것이 바람직하다.

일대다 매핑은 생각보다 간단하다. 1인 쪽에 @OneToMany, @JoinColumn(name="TEAM_ID") 만 걸어주면 알아서 Team이 연관 관계의 주인이 된다. DB에도 값이 올바르게 들어가는 것을 볼 수 있다.

일대다 양방퍙 매핑도 구현이 가능하다. 이건 실제로 JPA가 지원하는 것은 아니지만, 억지로 구현해낼 수는 있다. 다수인 쪽에도 @ManyToOne, @JoinColumn(name="TEAM_ID", insertable=false, updatable=false) 를 걸어주면 된다. 이렇게 되면 다수인 쪽에서는 읽기 기능만 가능하다.

** 일대다 매핑은 실제로 거의 쓰이지 않는다. 단점이 뚜렷하다. Table에서는 N인 쪽이 외래 키를 관리하는데, 객체에서 연관관게의 주인을 1로 설정하면 값을 변경했을 때 다른 table에 update 쿼리가 날아가는 것이다. 이건 JPA를 잘하는 사람이어도 많은 테이블들을 관리하다보면 실수하기 쉽다고 한다. 게다가 실무에서는 여러 사람들이 협업을 해야하기에 알아보기 쉽게 코드를 작성하는 것이 중요하다.

** 만약, 일대다 매핑이 객체 설계로서는 맞는 상황 (member에서 team으로 굳이 참조할 필요가 없는 상황) 이더라도 객체적으로는 조금 손해를 보고 member에서 team참조를 만들고 Table과 마찬가지로 N인쪽이 연관관계의 주인이 되도록 설계를 DB에 살짝 초점을 두어 하는 것이 바람직하다. 이 정도의 트레이드 오프는 오히려 유지보수 하기에 쉽다.

정리 : 결국 결론은 앞에서의 미흡한 설명과 같다. 다대일 연관관계 매핑을 사용하자.