### PR TITLE
Relationship mapping/#7

### DIFF
--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -12,15 +12,20 @@ public class JpaMain {
         tx.begin();
 
         try {
-            Member member = new Member();
-            member.setUsername("A");
-            em.persist(member);
-
             Team team = new Team();
             team.setName("teamA");
-            team.getMembers().add(member);
-
             em.persist(team);
+
+            Locker locker = new Locker();
+            em.persist(locker);
+
+            Member member = new Member();
+            member.setUsername("A");
+            member.setTeam(team);
+            member.setLocker(locker);
+
+            em.persist(member);
+
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Locker.java
+++ b/src/main/java/hellojpa/Locker.java
@@ -1,0 +1,2 @@
+package hellojpa;public class Locker {
+}

--- a/src/main/java/hellojpa/Locker.java
+++ b/src/main/java/hellojpa/Locker.java
@@ -1,2 +1,15 @@
-package hellojpa;public class Locker {
+package hellojpa;
+
+import javax.persistence.*;
+
+@Entity
+public class Locker {
+
+    @Id @GeneratedValue
+    @Column(name = "LOCKER_ID")
+    private Long id;
+
+    @OneToOne(mappedBy = "locker")
+    private Member member;
+
 }

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -15,6 +15,14 @@ public class Member {
     @Column(name = "USERNAME")
     private String username;
 
+    @ManyToOne
+    @JoinColumn(name = "TEAM_ID")
+    private Team team;
+
+    @OneToOne
+    @JoinColumn(name = "LOCKER_ID")
+    private Locker locker;
+
     public Long getId() {
         return id;
     }
@@ -31,5 +39,21 @@ public class Member {
 
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
+    }
+
+    public Locker getLocker() {
+        return locker;
+    }
+
+    public void setLocker(Locker locker) {
+        this.locker = locker;
     }
 }

--- a/src/main/java/hellojpa/Team.java
+++ b/src/main/java/hellojpa/Team.java
@@ -14,8 +14,7 @@ public class Team {
     @Column(name = "TEAM_NAME")
     private String name;
 
-    @OneToMany
-    @JoinColumn(name = "TEAM_ID")
+    @OneToMany(mappedBy = "team")
     private List<Member> members = new ArrayList<Member>();
 
     public List<Member> getMembers() {


### PR DESCRIPTION
일대일 연관 관계는 DB 상에서 주 테이블 혹은 대상 테이블, 둘 중 어떤 테이블이 외래 키(Foreign Key)를 가질 지 정할 수 있다. 그리고 외래 키에 데이터베이스 유니크(UNI) 제약 조건이 있어야 DB가 1:1 관계임을 인지한다. (?)

어노테이션은 @OneToOne, @JoinColumn 을 사용하고, @JoinColumn을 보고 해당 테이블에서 FK를 관리하는 것 같다. 단방향인 경우 연관 관계의 주인인 쪽에만 어노테이션을 적어주면 되고, 양방향인 경우 반대쪽에 @OneToOne(mappedby="")를 적어준다. 다대일 연관 관계 매핑과 매우 유사하다.

** 다대일 연관 관계와의 차이점을 생각해보면, 다대일 관계는 DB상에서 N쪽이 FK를 관리하는 것이 이미 정해져 있다. 그리고 이제 객체 상에서 개발자는 N인 쪽을 연관 관계의 주인으로 하는 것이 바람직하다. 
** 하지만, 일대일 연관 관계는 FK를 어느 테이블에서 관리할 지를 개발자가 정한다. 즉, 개발자가 먼저 객체 상에서 연관 관계의 주인을 설정하면 해당 테이블에서 FK를 관리하는 느낌 ? 순서가 역전된거 같다.

주 테이블에서 외래 키를 관리하는 경우는 앞에서의 예제들과 크게 다르지 않다.

대상 테이블에서 외래 키를 관리하는 경우, 이것도 크게 다를 건 없지만 차이점은, 이 경우에는 객체 상에서 주 테이블이 연관 관계의 주인이 될 수 없다. 단방향은 아예 지원하지를 않는다. 일대일 연관 관계에서는 외래 키를 가지고 있는 테이블이 항상 연관관계의 주인이 된다라고 생각하면 된다.

**** 나는 DB 테이블 상에서 FK를 누가 관리할 지를 작성된 코드를 보고 JPA가 판단한다고 생각해서 이해한 것인데, 이 이해가 정확한지 확실하지는 않다.

그렇다면 주 테이블과 대상 테이블 중 어느 테이블이 FK를 관리하는게 좋을까? 

주 테이블에서 외래키를 관리하는 경우는 객체 지향 개발자가 선호한다. 왜냐하면 주 테이블 ( 즉, 자주 조회되는 객체의 테이블) 만 조회해도 대상 테이블에 데이터가 있는지 확인이 가능하다. 주 테이블을 조회할 때 한번에 대상 테이블까지 조회해서 알려줄거니까. 하지만 단점은 만약 대상 테이블에 값이 없을 경우, 외래 키에 null을 허용해야 한다는 DB상에서 치명적인 단점이 있다.

대상 테이블에서 외래키를 관리하는 경우는 데이터베이스 개발자가 선호한다. 장점은 주 테이블과 대상 테이블을 일대일에서 일대다 관계로 변경할 때 테이블 구조를 유지하기 쉽다. 보통 주 테이블은 1로 쭉 갈때가 많지만 대상 테이블은 미래에 N으로 변할 수도 있다. 즉, DB 상에서만 보면 미래에 N이 될 가능성이 있는 쪽에서 FK를 관리하는 것이 좋다. 하지만 단점은 프록시 기능의 한계로 지연 로딩으로 설정해도 항상 즉시 로딩된다는 점이 있다 (?)