### PR TITLE
#8 다대다(N:M) 연관관계 매핑

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
-            <version>5.3.10.Final</version>
+            <version>5.4.13.Final</version>
         </dependency>
         <!-- H2 데이터베이스 -->
         <dependency>

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -12,20 +12,6 @@ public class JpaMain {
         tx.begin();
 
         try {
-            Team team = new Team();
-            team.setName("teamA");
-            em.persist(team);
-
-            Locker locker = new Locker();
-            em.persist(locker);
-
-            Member member = new Member();
-            member.setUsername("A");
-            member.setTeam(team);
-            member.setLocker(locker);
-
-            em.persist(member);
-
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -3,7 +3,9 @@ package hellojpa;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 @Entity
 public class Member {
@@ -22,6 +24,9 @@ public class Member {
     @OneToOne
     @JoinColumn(name = "LOCKER_ID")
     private Locker locker;
+
+    @OneToMany(mappedBy = "member")
+    private List<Order> orders = new ArrayList<>();
 
     public Long getId() {
         return id;

--- a/src/main/java/hellojpa/Order.java
+++ b/src/main/java/hellojpa/Order.java
@@ -1,0 +1,38 @@
+package hellojpa;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "ORDERS")
+public class Order {
+
+    @Id @GeneratedValue
+    @Column(name = "ORDER_ID")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "PRODUCT_ID")
+    private Product product;
+
+    public Member getMember() {
+        return member;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+}

--- a/src/main/java/hellojpa/Product.java
+++ b/src/main/java/hellojpa/Product.java
@@ -1,0 +1,18 @@
+package hellojpa;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Product {
+
+    @Id @GeneratedValue
+    @Column(name = "PRODUCT_ID")
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "product")
+    private List<Order> orders = new ArrayList<>();
+}


### PR DESCRIPTION
다대다 연관 관계의 매핑은 두 가지 방법으로 구현이 가능하나, 첫 번째 방법은 실무에서 사용하지 못한다고 봐도 무방하다.

첫 번째 방법으로는, JPA에서 다대다 관계 매핑을 @ManyToMany로 지원한다. member와 product간의 관계가 다대다 관계일 경우에 서로를 collection으로 참조하고, manytomany 어노테이션과 * Jointable (JoinColumn이 아님) 어노테이션을 추가해주면 된다. 주인인 쪽에는 jointable, 반대쪽에는 mappedby로 잡아주면 된다. 주인을 설정하는 기준은 다대다 관계이기에 딱히 없다. 이 방법은 DB상 중간에 table을 만들어 member_product가 member의 pk와 product의 pk를 자신의 pk및 fk로 관리를 하게 된다. 치명적인 단점으로는 새로운 항목들을 추가할 수 없다고 한다. ex) 수량, 가격 등등. 실무에서 사용할 일이 없기에 개념적으로만 알아두자.

두 번째 방법으로는, 다대다 관계를 일대다, 다대일 관계로 풀어내는 것이다. 첫 번째 방법에서 중간에 table을 만들었다면, 이 방법에서는 table을 entity로 승격하여 관계를 만들어 낸다. 이번 예제에서는 order라는 Entity를 만들었다. 이렇게 되면 order는 ORDER_ID라는 자신의 PK를 가지게 되고 새로운 항목들도 자유롭게 엔티티에서 추가가 가능하겠다. 엔티티 이름이 order일 경우에 주의할점으로는 ** DB는 order를 하나의 명령어로 인식하기 때문에 반드시 table명을 ORDERS로 설정해주는 것이 좋다. 

첫 번째 방법은 쓰지 않지만, DB상에서 중간 테이블이 양쪽 table의 pk들을 묶어서 자신의 pk및 fk로 관리할지, 그냥 자신의 고유한 pk를 가질지에 대한 것은 각각이 장단점이 있다고 한다. 김영한 님은 후자로 개발을 하는 것이 경험상 좋다고 한다. 어플리케이션이 갈수록 커지는 과정에서 pk는 그냥 의미없는 값 ( 즉, 다른 table에 종속적이지 않은 값) 으로 설정하는 것이 좋다고 한다.