### PR TITLE
#1 상속관계 매핑 (조인, 단일테이블, 구현클래스마다 테이블)

### DIFF
--- a/src/main/java/hellojpa/Album.java
+++ b/src/main/java/hellojpa/Album.java
@@ -1,0 +1,32 @@
+package hellojpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Album extends Item {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String artist;
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getArtist() {
+        return artist;
+    }
+
+    public void setArtist(String artist) {
+        this.artist = artist;
+    }
+}

--- a/src/main/java/hellojpa/Book.java
+++ b/src/main/java/hellojpa/Book.java
@@ -1,0 +1,41 @@
+package hellojpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Book extends Item {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String author;
+    private String isbn;
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getIsbn() {
+        return isbn;
+    }
+
+    public void setIsbn(String isbn) {
+        this.isbn = isbn;
+    }
+}

--- a/src/main/java/hellojpa/Item.java
+++ b/src/main/java/hellojpa/Item.java
@@ -1,0 +1,41 @@
+package hellojpa;
+
+import javax.persistence.*;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
+public abstract class Item {
+
+    @Id @GeneratedValue
+    @Column(name = "ITEM_ID")
+    private Long id;
+
+    private String name;
+
+    private int price;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public void setPrice(int price) {
+        this.price = price;
+    }
+}

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -13,6 +13,14 @@ public class JpaMain {
 
         try {
 
+            Movie movie = new Movie();
+            movie.setActor("A");
+            movie.setDirector("B");
+            movie.setName("탑건:매버릭");
+            movie.setPrice(10000);
+
+            em.persist(movie);
+
             tx.commit();
         } catch (Exception e) {
             tx.rollback();

--- a/src/main/java/hellojpa/Movie.java
+++ b/src/main/java/hellojpa/Movie.java
@@ -1,0 +1,39 @@
+package hellojpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Movie extends Item {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String director;
+    private String actor;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDirector() {
+        return director;
+    }
+
+    public void setDirector(String director) {
+        this.director = director;
+    }
+
+    public String getActor() {
+        return actor;
+    }
+
+    public void setActor(String actor) {
+        this.actor = actor;
+    }
+}


### PR DESCRIPTION
객체에서는 상속 관계라는 핵심 개념이 있다. 하지만 관계형 데이터베이스에서는 상속 관계를 지원하지 않는다.

우리는 지금까지 객체와 관계형DB를 매핑하는 ORM에 대해서 공부하고 있다. 그렇다면 관계형 DB에 객체의 상속 관계를 어떻게 매핑해야 할까? 

관계형 DB에는 슈퍼타입, 서브타입 관계라는 객체 상속과 유사한 모델링 기법이 있다. 우리는 JPA를 통해 객체의 상속 관계와 DB의 슈퍼타입 서브타입 관계를 매핑할 것이다. 

슈퍼타입-서브타입 논리 모델을 실제 물리 모델로 구현하는데에는 세 가지 방법이 있다.

1. 각각 테이블로 변환 -> 조인 전략 (JOINED)
2. 통합 테이블로 변환 -> 단일 테이블 전략 (SINGLE_TABLE)
3. 서브타입 테이블로 변환 -> 구현 클래스마다 테이블 전략 (TABLE_PER_CLASS)

사실 코드에 큰 변화가 있지는 않다. 개발자는 객체 지향적으로 코드를 작성하기만 하고, 몇 개의 어노테이션을 붙여주면 그에 따라 JPA가 알아서 DB를 만드는 것이다.

따라서 예제에서 그냥 부모 클래스인 Item, 자식 클래스인 Album, Movie, Book 클래스들을 만든다. 그리고 부모 클래스에 @Inheritance(strategy=InheritanceType.xx) 를 붙여주면 된다. 부모 클래스에 @DiscriminatorColumn 을 붙여주면 어떤 DTYPE이 저장되었는지 알 수 있다. 이건 항상 붙여주는 것이 좋다. (DB 입장에서)

세 가지 전략 중 세 번째 전략인 구현 클래스마다 테이블 전략은 사실 실무에서 쓰지 않는다. 이 전략은 객체 지향 개발자의 입장에서도, DB 전문가 입장에서도 좋지 않다. 저장 공간의 효율도 떨어지고, 여러 자식 테이블을 함께 조회할 때 자식 테이블을 union 해야하기에 성능이 느리다. 그리고 Item 이라는 부모 클래스의 테이블이 애초에 만들어 지지 않아 다른 테이블에서 Item의 price(공통된 부분)을 조회하려고 하면 자식 테이블을 싹 다 조회해야 하는 번거로움이 있다. 그냥 쓰지 말자.

그렇다면, 조인 전략 vs 단일 테이블 전략 구도 인데, 디폴트로는 조인 전략을 쓴다고 생각하고 테이블이 너무 간단하다 싶으면 단일 테이블 전략을 쓴다고 생각하자.

조인 전략의 장점은 일단 테이블이 깔끔하게 정규화 되어 있다. 공통된 부분은 부모 테이블이 가지고 있어 저장 공간도 효율적이다. 단점으로는 자식 테이블을 조회하고 싶다 하면 join을 해야 하기에 쿼리가 조금 복잡하고 성능이 낮다는 점이 있다. 저장할 때도 부모에 한번, 자식에 한번 insert 쿼리가 두 번 나간다. 근데 뭐 이런건 사소한 문제라 조인 전략이 가장 기본이 된다고 한다.

단일 테이블 전략의 장점은 말 그대로 하나의 테이블만 만들기 때문에 저장이던 조회던 쿼리가 간단하여 성능이 빠르다. 하지만 자식 엔티티가 매핑한 컬럼은 모두 null을 허용해야 한다는 단점이 있다. 또한, 테이블이 너무 커지면 상황에 따라 오히려 조인 전략보다 조회 성능이 느릴 수 있다.