### PR TITLE
#2 MappedSuperclass

### DIFF
--- a/src/main/java/hellojpa/BaseEntity.java
+++ b/src/main/java/hellojpa/BaseEntity.java
@@ -1,0 +1,15 @@
+package hellojpa;
+
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+public class BaseEntity {
+
+    private String createdBy;
+    private LocalDateTime createdAt;
+
+    private String lastModifiedBy;
+    private LocalDateTime lastModifiedAt;
+
+}

--- a/src/main/java/hellojpa/Item.java
+++ b/src/main/java/hellojpa/Item.java
@@ -3,7 +3,7 @@ package hellojpa;
 import javax.persistence.*;
 
 @Entity
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn
 public abstract class Item {
 

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -13,14 +13,6 @@ public class JpaMain {
 
         try {
 
-            Movie movie = new Movie();
-            movie.setActor("A");
-            movie.setDirector("B");
-            movie.setName("탑건:매버릭");
-            movie.setPrice(10000);
-
-            em.persist(movie);
-
             tx.commit();
         } catch (Exception e) {
             tx.rollback();

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -8,7 +8,7 @@ import java.util.Date;
 import java.util.List;
 
 @Entity
-public class Member {
+public class Member extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "MEMBER_ID")

--- a/src/main/java/hellojpa/Team.java
+++ b/src/main/java/hellojpa/Team.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-public class Team {
+public class Team extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "TEAM_ID")


### PR DESCRIPTION
우선 MappedSuperclass는 상속관계 매핑이 아니다. 객체에서 공통적으로 사용하는 필드가 많아 공통 매핑 정보가 필요할 때, BaseEntity를 따로 만들어 준다. BaseEntity는 그 자체로 사용되는 일이 없기 때문에 abstract class로 만들어 준다. 

그리고 공통 속성들을 사용할 클래스들은 BaseEntity를 상속받으면 된다. 그렇게 되면 객체에서는 중복되는 코드를 방지할 수 있고, DB에는 원래 의도대로 상속관계 없이 매핑이 된다.

** 주의할 점
@MappedSuperclass는 상속관계 매핑이 아니다. 엔티티가 아니므로 테이블과 매핑되지도 않는다. 당연히 조회나 검색도 불가하다.

주로 등록일, 수정일, 등록자, 수정자 같은 전체 엔티티에서 공통적으로 사용하는 정보를 모을 때 사용한다. 