### PR TITLE
#1 프록시

### DIFF
--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -13,9 +13,28 @@ public class JpaMain {
 
         try {
 
+            Member member = new Member();
+            member.setUsername("member1");
+            em.persist(member);
+
+            em.flush();
+            em.clear();
+
+//            Member findMember = em.find(Member.class, member.getId());
+            Member reference = em.getReference(Member.class, member.getId());
+
+            System.out.println(reference.getUsername());
+
+            Member member2 = em.find(Member.class, member.getId());
+
+            System.out.println(member2.getClass());
+            System.out.println(member2 == reference);
+
+
             tx.commit();
         } catch (Exception e) {
             tx.rollback();
+            e.printStackTrace();
         } finally {
             em.close();
         }

--- a/src/main/java/hellojpa/Locker.java
+++ b/src/main/java/hellojpa/Locker.java
@@ -9,7 +9,4 @@ public class Locker {
     @Column(name = "LOCKER_ID")
     private Long id;
 
-    @OneToOne(mappedBy = "locker")
-    private Member member;
-
 }

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -8,7 +8,7 @@ import java.util.Date;
 import java.util.List;
 
 @Entity
-public class Member extends BaseEntity {
+public class Member {
 
     @Id @GeneratedValue
     @Column(name = "MEMBER_ID")
@@ -20,10 +20,6 @@ public class Member extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "TEAM_ID")
     private Team team;
-
-    @OneToOne
-    @JoinColumn(name = "LOCKER_ID")
-    private Locker locker;
 
     @OneToMany(mappedBy = "member")
     private List<Order> orders = new ArrayList<>();
@@ -54,11 +50,4 @@ public class Member extends BaseEntity {
         this.team = team;
     }
 
-    public Locker getLocker() {
-        return locker;
-    }
-
-    public void setLocker(Locker locker) {
-        this.locker = locker;
-    }
 }

--- a/src/main/java/hellojpa/Team.java
+++ b/src/main/java/hellojpa/Team.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-public class Team extends BaseEntity {
+public class Team {
 
     @Id @GeneratedValue
     @Column(name = "TEAM_ID")


### PR DESCRIPTION
프록시라는 개념을 알기 전에, 왜 이런 개념이 만들어지게 되었는지 알면 더 이해가 쉽다.

Member 객체에서 Team 객체의 참조를 가지고 있다고 가정하자. 그렇다면 Member 객체를 조회할 때 Team도 함께 조회를 해야하나? 만약 Team의 정보를 활용하지 않을 것이라면, 조회를 하지 않는 것이 성능에 도움이 될 것이다.

프록시라는 개념은 조회를 하는 것처럼 보이지만 사실 즉시 DB에 조회 쿼리를 보내는 것이 아닌, 일단 가짜 프록시 객체를 반환하고 실제로 객체 사용이 이루어질 때 조회를 한다.

그런데, 이번 예제에서는 프록시 객체가 처음에는 비어있고 처음 사용할 때 DB에 조회를 해서 Member를 다 채운다. 위의 경우를 아직 해결하지 못한 것인가?? Team객체에 대한 정보는 아직 사용하지 않았는데 같이 조회가 되었다. 이는 지연로딩과 관계가 있어 보인다.

일단 프록시의 개념을 더 나가보자면, 프록시 객체를 반환 받기 위해서는 기존의 em.find()가 아닌 em.getReference()를 사용하면 된다. 프록시 객체는 실제 클래스를 상속 받아서 만들어진다. 해당 클래스의 메서드는 모두 가지고 있다. 추가로 프록시 객체는 실제 객체의 참조를 보관한다. 이 정보는 처음에는 비어있지만 프록시 객체를 호출하면(초기화) 그 때에야 DB에 조회를 해서 실체 객체를 가리키게 된다. DB에 조회하는 과정에서 영속성 컨텍스트에 해당 실제 객체가 저장되는 것 같다. 

프록시 객체는 처음 사용할 때 한번만 초기화를 한다. 그리고 주의할 점은 초기화를 한다고 해서 그 이후에 실제 객체 타입이 되는 것은 아니다. 프록시 타입을 계속 유지한다. 이게 왜 중요하냐면 타입 체크를 할 때 다른 실제 객체와 타입 체크를 ==으로 할 경우 반드시 false가 난다. 따라서 타입 체크를 instance of 를 사용해서 해야 한다. ex) m1 instance of Member

강의 초반부 JPA에서 같은 객체를 조회했을 경우 동일성을 보장한다는 원칙에 대해서 배웠다. 이는 프록시에도 해당이 되어 같은 객체를 한번은 em.find, 한번은 em.getReference로 조회했을 경우 내부적으로 먼저 조회한 타입을 따라가게 반환한다. 
강의 자료에서는 "영속성 컨텍스트에 찾는 엔티티가 이미 있으면 em.getReference()를 해도 실제 엔티티 반환" 이라고 했는데, 이게 맞는지는 모르겠다. 처음에 em.getReference()를 해도 영속성 컨텍스트에 엔티티가 저장이 되는것 같은데 그 이후에 em.find를 하던 em.getReference를 하던 같은 객체를 조회할 경우에 제일 먼저 조회된 프록시 객체가 반환된다. 그냥 맨 앞에서 한걸 따라간다라고 생각하자.

프록시 초기화는 영속성 컨텍스트를 통해 이루어지기 때문에, 준영속 상태일 때 혹은 em.close()이후에 프록시를 초기화 하려는 시도를 할 경우 LazyInitializationException 예외가 터진다. 실무에서 많이 겪는다고 한다.

그래서 프록시 인스턴스의 초기화 여부를 확인하는 방법이 있다. emf.getPersistenceUnitUtil().isLoaded(member)를 사용하면 된다. 클래스 확인 방법은 .getclass() 하면 되고 JPA 표준에서 강제 초기화는 없지만 hibernate 에서는 Hibernate.initialize(entity)로 지원한다.

하지만 사실 프록시 개념은 지금은 많이 사용하지 않는다고 한다. 그럼에도 자세히 다룬 이유는 즉시로딩과 지연 로딩을 깊이 있게 이해하는데에 필요하다.