### PR TITLE
#2 즉시 로딩과 지연 로딩

### DIFF
--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -13,23 +13,30 @@ public class JpaMain {
 
         try {
 
+            Team team = new Team();
+            team.setName("teamA");
+            em.persist(team);
+
             Member member = new Member();
             member.setUsername("member1");
+            member.setTeam(team);
             em.persist(member);
 
             em.flush();
             em.clear();
 
 //            Member findMember = em.find(Member.class, member.getId());
-            Member reference = em.getReference(Member.class, member.getId());
+//            Team findTeam = findMember.getTeam();
 
-            System.out.println(reference.getUsername());
+            List<Member> members = em.createQuery("select m from Member m join fetch m.team", Member.class)
+                    .getResultList();
 
-            Member member2 = em.find(Member.class, member.getId());
 
-            System.out.println(member2.getClass());
-            System.out.println(member2 == reference);
-
+//            System.out.println(findTeam.getClass());
+//
+//            System.out.println("==============");
+//            System.out.println(findTeam.getName());
+//            System.out.println("==============");
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -17,7 +17,7 @@ public class Member {
     @Column(name = "USERNAME")
     private String username;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "TEAM_ID")
     private Team team;
 


### PR DESCRIPTION
저번 시간에 배운 프록시를 사용하여 지연 로딩을 구현할 수 있다.

@ManyToOne, @OneToOne은 fetch type default가 EAGER로 설정되어 있기 때문에, 이를 LAZY로 바꾸어 주면 Member를 조회할 때 Team은 프록시 객체 (가짜 객체)를 반환한다. 그리고 team내부의 메서드들을 사용하는 시점에 초기화 된다. ** member.getTeam() 시점에 초기화 되는것이 아님!

이론적으로는 Member와 Team을 자주 함께 사용한다면, fetch type을 EAGER로 설정하여 한번에 조회하는 것이 성능에 도움이 되긴 한다. 하지만 그건 JPA의 em.find()를 통해 조회할 때의 이야기이다. em.find()는 JPA가 내부적으로 join을 해주어 한꺼번에 조회를 한다. 하지만 실무에서는 개발자가 직접 JPQL을 작성하여 쿼리를 날리는 경우가 많다. 그 경우에는, 일단 JPQL이 SQL로 변환되어 member만 싹 다 조회를 한 후에 뒤늦게 fetchType이 EAGER인 것을 확인하고 member마다 Team을 일일이 조회하는 쿼리가 날아간다. 이 문제를 N+1 문제라고 부른다. 1개의 쿼리를 날렸는데 예상치 못한 N개의 쿼리가 추가적으로 발생한다는 의미이다. 이는 성능적으로 부정적인 영향을 준다. 
** 실무에서 성능이 왜이렇게 떨어질까.. 라는 경우에 대부분 fetchType이 EAGER로 되어있는 문제이다. 

따라서 실제 실무에서는 모든 연관관계에 반드시 지연로딩!! 을 모두 적용한다. 그러면 만약 지연로딩이지만 한번에 조회하고 싶은 경우에는 어떻게 할까? 이를 해결하는 방법은 세 가지가 있다. JPQL fetch join, 엔티티 그래프 기능(어노테이션),batchSize 이다. 우선 이번 예제에서는 fetch join을 간단히 살펴보았고 대부분 이 경우로 해결한다고 한다. 


