### PR TITLE
#3 cascade(영속성 전이)와 orphan(고아 객체)

### DIFF
--- a/src/main/java/hellojpa/Child.java
+++ b/src/main/java/hellojpa/Child.java
@@ -1,0 +1,37 @@
+package hellojpa;
+
+import javax.persistence.*;
+
+@Entity
+public class Child {
+
+    @Id @GeneratedValue
+    @Column(name = "CHILD_ID")
+    private Long id;
+
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "PARENT_ID")
+    private Parent parent;
+
+    public Parent getParent() {
+        return parent;
+    }
+
+    public void setParent(Parent parent) {
+        this.parent = parent;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -13,30 +13,22 @@ public class JpaMain {
 
         try {
 
-            Team team = new Team();
-            team.setName("teamA");
-            em.persist(team);
+            Child child1 = new Child();
+            Child child2 = new Child();
 
-            Member member = new Member();
-            member.setUsername("member1");
-            member.setTeam(team);
-            em.persist(member);
+            Parent parent = new Parent();
+            parent.addChild(child1);
+            parent.addChild(child2);
+
+            em.persist(parent);
 
             em.flush();
             em.clear();
 
-//            Member findMember = em.find(Member.class, member.getId());
-//            Team findTeam = findMember.getTeam();
+            Parent findParent = em.find(Parent.class, parent.getId());
 
-            List<Member> members = em.createQuery("select m from Member m join fetch m.team", Member.class)
-                    .getResultList();
+            em.remove(findParent);
 
-
-//            System.out.println(findTeam.getClass());
-//
-//            System.out.println("==============");
-//            System.out.println(findTeam.getName());
-//            System.out.println("==============");
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Parent.java
+++ b/src/main/java/hellojpa/Parent.java
@@ -1,0 +1,43 @@
+package hellojpa;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Parent {
+
+    @Id @GeneratedValue
+    @Column(name = "PARENT_ID")
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Child> children = new ArrayList<>();
+
+    public void addChild(Child child) {
+        children.add(child);
+        child.setParent(this);
+    }
+
+    public List<Child> getChildren() {
+        return children;
+    }
+
+    public void setChildren(List<Child> children) {
+        this.children = children;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
일단, 이번 예제에서 부모(Parent) 클래스와 자식(Child) 클래스를 만들었는데, 이는 상속(Inheritance)에서의 관계와는 아무 상관 없는 관계라는 것을 주의하자. 이번 예제에서 두 클래스는 다대일 양방향 연관관계로 매핑되어 있을 뿐이다. 

cascade(영속성 전이) 는 프록시나 지연로딩, 연관 관계 세팅과 아무 관련이 없다. 혼동하지 말자. cascade는 양방향으로 이미 매핑되어 있을 때(혹은 단방향도 가능할 것 같다), @OneToMany 나 @OneToOne에 추가할 수 있는 속성이다. CascadeType 중 주로 쓰는 것은 Persist, ALL이다.

CascadeType을 ALL로 설정할 경우에는 두 클래스의 생명주기가 완전히 동일하거나 비슷할 때 사용한다. 그렇게 되면 부모 엔티티를 persist할 때 자식 엔티티도 함께 persist된다. remove도 마찬가지.

부모와 자식이 저장(persist)은 같은 시점에 하되, 생명주기가 다를 때에는 CascadeType을 Persist로 설정한다.

즉, CASCADE 영속성 전이란, 특정 엔티티를 영속 상태로 만들 때 연관된 엔티티도 함께 영속 상태로 만들고 싶을 때 사용하는 기능이다.

CASCADE 기능을 언제 쓰나? 두 가지 조건을 만족해야 함.
1. 두 엔티티의 생명주기가 거의 동일할 것
2. 관리를 당하는 엔티티가 관리하는 엔티티에만 소유될 때

뭔가 비슷한 개념? 으로 고아 객체에 대한 소개를 하였다. 위와 마찬가지로 @OneToMany, @OneToOne에 추가할 수 있는 속성으로, 부모 엔티티와 연관관계가 끊어진 자식 엔티티를 자동으로 삭제한다. 이번 예제에서만 부모-자식의 관계인 것이지 그냥 단순히 다대일관계에서 1인쪽에서 설정하는 속성이다.

다대일 양방향 관계에서 1인 엔티티는 N인 엔티티들을 List로 가지고 있다. 여기에 Cascade나 orphanRemoval같은 속성을 추가하는 것이다. 그렇게 되면 1(parent)쪽에서 N(child) 엔티티들의 생명주기를 관리하게 된다.
*** 주의할 점은 child를 알고있는(관리하는) 곳이 하나일 때만 사용해야 한다. -> 특정 엔티티가 개인 소유 할때만!!

child를 여기저기서 쓰는데 parent에서 그 생명주기를 관리해버리면 곤란하다.

영속성 전이 + 고아 객체 기능을 모두 활성화하면 어떻게 되냐 ??

결국 두 기능 모두 엔티티의 생명 주기와 관련이 있다. cascade는 em.persist나 em.remove를 할 때 함께 영속되고, 삭제된다. orphanRemoval은 1인쪽의 List에서 getChild().remove(0) 이런 식으로 삭제가 가능하다.
** orphanRemoval만 true로 해도 부모를 지우면 자식도 지워진다. 왜? 부모가 지워지는 것은 곧 고아 객체라는 말이니까.

두 옵션을 모두 활성화하는 것이 무슨 의미인가? 바로 엔티티의 생명주기를 JPA가 관리하는 것이 아니라, 1(parent)인 엔티티에서 N(child)인 엔티티의 생명주기를 관리할 수 있다. 이 개념은 도메인 주도 설계 (DDD) 의 Aggregate Root 개념을 구현할 때 유용하다.

