### PR TITLE
#2 불변 객체, 값 타입 비교

### DIFF
--- a/src/main/java/hellojpa/Address.java
+++ b/src/main/java/hellojpa/Address.java
@@ -1,6 +1,7 @@
 package hellojpa;
 
 import javax.persistence.Embeddable;
+import java.util.Objects;
 
 @Embeddable
 public class Address {
@@ -21,7 +22,7 @@ public class Address {
         return city;
     }
 
-    public void setCity(String city) {
+    private void setCity(String city) {
         this.city = city;
     }
 
@@ -29,7 +30,7 @@ public class Address {
         return street;
     }
 
-    public void setStreet(String street) {
+    private void setStreet(String street) {
         this.street = street;
     }
 
@@ -37,7 +38,20 @@ public class Address {
         return zipcode;
     }
 
-    public void setZipcode(String zipcode) {
+    private void setZipcode(String zipcode) {
         this.zipcode = zipcode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address address = (Address) o;
+        return Objects.equals(city, address.city) && Objects.equals(street, address.street) && Objects.equals(zipcode, address.zipcode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(city, street, zipcode);
     }
 }

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -4,6 +4,7 @@ import javax.persistence.*;
 import java.util.List;
 
 public class JpaMain {
+
     public static void main(String[] args) {
         EntityManagerFactory emf = Persistence.createEntityManagerFactory("hello");
         EntityManager em = emf.createEntityManager();
@@ -12,11 +13,16 @@ public class JpaMain {
         tx.begin();
 
         try {
-            Member member = new Member();
-            member.setUsername("memberA");
-            member.setHomeAddress(new Address("city", "street", "00000"));
 
-            em.persist(member);
+            Address address = new Address("city", "street", "00000");
+
+            Member member1 = new Member();
+            member1.setHomeAddress(address);
+            em.persist(member1);
+
+            Member member2 = new Member();
+            member2.setHomeAddress(address);
+            em.persist(member2);
 
 
             tx.commit();

--- a/src/main/java/hellojpa/Period.java
+++ b/src/main/java/hellojpa/Period.java
@@ -20,7 +20,7 @@ public class Period {
         return startDate;
     }
 
-    public void setStartDate(LocalDateTime startDate) {
+    private void setStartDate(LocalDateTime startDate) {
         this.startDate = startDate;
     }
 
@@ -28,7 +28,7 @@ public class Period {
         return endDate;
     }
 
-    public void setEndDate(LocalDateTime endDate) {
+    private void setEndDate(LocalDateTime endDate) {
         this.endDate = endDate;
     }
 }

--- a/src/main/java/hellojpa/ValueMain.java
+++ b/src/main/java/hellojpa/ValueMain.java
@@ -1,0 +1,12 @@
+package hellojpa;
+
+public class ValueMain {
+    public static void main(String[] args) {
+
+        Address address1 = new Address("city", "street", "00000");
+        Address address2 = new Address("city", "street", "00000");
+
+        System.out.println((address1 == address2));
+        System.out.println(address1.equals(address2));
+    }
+}


### PR DESCRIPTION
값 타입은 자바 기본 타입을 제외하고는, 개발자가 직접 만드는 클래스이다. 엔티티와는 다르게 값으로만 사용되는 클래스이다. 값 타입이라는 것은 복잡한 객체 세상을 조금이라도 단순화하려고 만든 개념이다. 따라서 값 타입은 단순하고 안전하게 다룰 수 있어야 한다.

자바 기본 타입은 애초에 공유가 되지 않는다고 저번 예제에서 설명했다. 임베디드 타입 같은 값 타입은 여러 엔티티에서 공유가 가능하다.
Address address1 = new Address("", "", "");
Address address2 = address1;

이런 식으로 대입할 때 타입만 맞으면 임베디드 타입은 객체 타입이므로 참조 값을 넘겨버린다. 그렇게 되면 같은 address를 공유하게 되어 하나를 수정하면 싹 다 바뀌어 버리는 참사가 벌어진다.

이를 방지하기 위해서는
Address address2 = new Address(address1.getCity() .... ) 처럼 통으로 새로 만들어 주는 방법이 있다.
이 방법을 값을 복사해서 사용한다고 한다. 하지만 매번 이렇게 하는 것은 번거롭다.

*** 임베디드 타입의 클래스 내부의 필드를 수정할 수 없게 만들면 부작용을 원천 차단할 수 있다. 따라서 값 타입은 무조건!! 불변 객체 (immutable object)로 설계해야 한다. 생성자로만 값을 설정하고 수정자(Setter)를 만들지 않으면 된다. 
ex) Integer, String은 자바가 제공하는 대표적인 불변 객체이다.

불변이라는 작은 제약으로 부작용이라는 큰 재앙을 막을 수 있다!!!

값을 변경하고 싶은 경우에는 생성자로 새로운 객체를 만들어서 통으로 갈아줘야 한다.

값 타입의 비교. 두 가지 종류가 있다.
1. 동일성 비교 : 인스턴스의 참조 값을 비교한다. == 사용
2. 동등성 비교 : 인스턴스의 값을 비교한다. equals()사용

값 타입은 동등성 비교를 해야 한다. 왜? 참조 값은 당연히 다를테니까. 내가 정의한 임베디드 타입(클래스)에 equals를 override 해주어야 한다. equals도 재정의 해주지 않으면 ==을 default로 함.