### PR TITLE
#3 값 타입 컬렉션

### DIFF
--- a/src/main/java/hellojpa/AddressEntity.java
+++ b/src/main/java/hellojpa/AddressEntity.java
@@ -1,0 +1,56 @@
+package hellojpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
+
+@Entity
+@Table(name = "ADDRESS")
+public class AddressEntity {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private Address address;
+
+    public AddressEntity() {}
+
+    public AddressEntity(Address address) {
+        this.address = address;
+    }
+
+    public AddressEntity(String city, String street, String zipcode) {
+        this.address = new Address(city, street, zipcode);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AddressEntity that = (AddressEntity) o;
+        return Objects.equals(id, that.id) && Objects.equals(address, that.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, address);
+    }
+}

--- a/src/main/java/hellojpa/JpaMain.java
+++ b/src/main/java/hellojpa/JpaMain.java
@@ -2,6 +2,7 @@ package hellojpa;
 
 import javax.persistence.*;
 import java.util.List;
+import java.util.Set;
 
 public class JpaMain {
 
@@ -14,16 +15,42 @@ public class JpaMain {
 
         try {
 
-            Address address = new Address("city", "street", "00000");
+            Member member = new Member();
 
-            Member member1 = new Member();
-            member1.setHomeAddress(address);
-            em.persist(member1);
+            member.setUsername("member1");
+            member.getFavoriteFoods().add("닭가슴살");
+            member.getFavoriteFoods().add("고구마");
+            member.getFavoriteFoods().add("샐러드");
 
-            Member member2 = new Member();
-            member2.setHomeAddress(address);
-            em.persist(member2);
+            member.getAddressHistory().add(new AddressEntity("oldCity1", "street", "10001"));
+            member.getAddressHistory().add(new AddressEntity("oldCity2", "street", "10002"));
+            member.getAddressHistory().add(new AddressEntity("oldCity3", "street", "10003"));
 
+            em.persist(member);
+
+            em.flush();
+            em.clear();
+
+            Member findMember = em.find(Member.class, member.getId());
+
+            Set<String> favoriteFoods = findMember.getFavoriteFoods();
+
+            favoriteFoods.add("아아");
+            for (String favoriteFood : favoriteFoods) {
+                System.out.println(favoriteFood);
+            }
+
+            favoriteFoods.remove("닭가슴살");
+            favoriteFoods.add("치킨");
+
+            List<AddressEntity> addressHistory = findMember.getAddressHistory();
+
+//            addressHistory.remove(new Address("oldCity2", "street", "10002"));
+//            addressHistory.add(new Address("newCity2", "street", "10002"));
+
+//            addressHistory.remove(0);
+//            addressHistory.remove(new AddressEntity("oldCity2", "street", "10002"));// 이건 안되네.
+            
 
             tx.commit();
         } catch (Exception e) {

--- a/src/main/java/hellojpa/Member.java
+++ b/src/main/java/hellojpa/Member.java
@@ -3,9 +3,7 @@ package hellojpa;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 @Entity
 public class Member {
@@ -40,6 +38,45 @@ public class Member {
 
     @Embedded
     private Period workPeriod;
+
+    @ElementCollection
+    @CollectionTable(name = "FAVORITE_FOOD",
+            joinColumns = @JoinColumn(name = "MEMBER_ID"))
+    @Column(name = "FOOD_NAME")
+    private Set<String> favoriteFoods = new HashSet<>();
+
+//    @ElementCollection
+//    @CollectionTable(name = "ADDRESS",
+//            joinColumns = @JoinColumn(name = "MEMBER_ID"))
+//    private List<Address> addressHistory = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "MEMBER_ID")
+    private List<AddressEntity> addressHistory = new ArrayList<>();
+
+    public Address getWorkAddress() {
+        return workAddress;
+    }
+
+    public void setWorkAddress(Address workAddress) {
+        this.workAddress = workAddress;
+    }
+
+    public Set<String> getFavoriteFoods() {
+        return favoriteFoods;
+    }
+
+    public void setFavoriteFoods(Set<String> favoriteFoods) {
+        this.favoriteFoods = favoriteFoods;
+    }
+
+    public List<AddressEntity> getAddressHistory() {
+        return addressHistory;
+    }
+
+    public void setAddressHistory(List<AddressEntity> addressHistory) {
+        this.addressHistory = addressHistory;
+    }
 
     public List<Order> getOrders() {
         return orders;


### PR DESCRIPTION
값 타입 컬렉션 이란, 엔티티 내부에 값 타입을 하나 이상 저장할 때 사용하는 개념이다. 주의할 점은 컬렉션은 엔티티 테이블 내부에 저장되지 않는다. DB에서 지원하지 않는다. 컬렉션은 따로 table을 하나 더 만들어 저장된다. 고유한 id를 가지지 않고, 소유한 엔티티의 id를 FK로 갖고, 내부 필드들을 묶어서 pk를 가져야 한다. pk 설정은 DB에서 따로 해주어야 하는 것 같다. 

이번 예제에서는 String(기본 값 타입)의 set인 FavoriteFood와 우리가 만든 Address(임베디드 타입)의 list인 AddressHistory를 Member 내부에 저장하였다.

컬렉션을 선언해주고, @ElementCollection, @CollectionTable을 사용하면 된다. @CollectionTable에서는 컬렉션을위해 새로 만들어진 table의 이름을 설정하고 fk의 이름을 맞춰주면 좋다.
** Address의 값 타입 컬렉션은 임베디드 타입의 컬렉션 이기 때문에 내부 컬럼명이 알아서 입력된다.
** 반면 String의 값 타입 컬렉션은 기본 값 타입 컬렉션 이기 때문에 이름을 따로 맞춰주는 것이 좋다.

값 타입 컬렉션을 저장, 조회, 수정해보는 코드를 작성해 보았다.
값 타입 컬렉션의 저장은 member에서 컬렉션을 get으로 받아서 .add 하여 구현된다.
값 타입 컬렉션의 조회는 지연 로딩 전략을 적용한다.

** 값 타입 컬렉션은 말그대로 이것도 결국은 값 타입이기 때문에 이를 소유한 엔티티만 persist해도 알아서 쿼리가 싹 날아간다. 값 타입 컬렉션은 영속성 전이(cascade) + 고아 객체 제거 기능을 필수로 가진다고 볼 수 있다.

값 타입 컬렉션은 수정이 특이하다. String의 컬렉션인 Favorite Food의 수정은 비교적 수월하게 되는데, AddressHistory가 문제다. 일단 remove( 여기에도 생성자를 이용해서 내가 삭제하고 싶은 항목과 완전히 동일한 값 타입을 써준다.) 컬렉션들은 대부분 비교를 할 때 .equals를 이용하기 때문에 삭제가 가능하다. 그래서 equals가 클래스에 잘 구현되어 있어야 한다.
게다가, remove와 add를 한 결과는 내가 원하는 대로 나오는데 쿼리를 보면 이상하다. table에서 하나만 빼고 수정된 값을 저장하는게 아니라 table을 싹 다 지우고 컬렉션에 남아있는 값들을 하나하나 다시 insert해서 저장한다.

위의 현상이 발생하는 이유는 값 타입은 엔티티와 달리 식별자(id)를 가지고 있지 않아 값이 변경되면 추적이 어렵기 때문이다. 그래서 그냥 변경 사항이 발생했다면 주인 엔티티와 관련된 모든 데이터를 삭제하고 최종 컬렉션에 남아있는 값들만 다시 저장하는 것이다. 대안책으로 @OrderColumn을 넣으면 우리가 원하는대로 update가 가능하긴 한데 이것도 문제가 있다고 한다. 
그래서 결론은? 이 방법은 쓰지 말자. 값 타입 컬렉션은 차라리 엔티티로 한 번 감싸서 일대다 관계로 연관관계를 설정하는 것이 해결 방법이다.

값 타입 컬렉션은 주인 엔티티가 명확한 특수한 녀석이기에 일대다 단방향 관계로 매핑을 해준다. (1이 연관관계의 주인이라는 말이다.), @OneToMany(cascade:all, orphanremoval:true), @JoinColumn을 이용하여 연관 관계를 매핑해준다. 그러면 이제 엔티티로서 고유한 식별자를 가질 것이다. 이러면 추적도 쉽고 쿼리 최적화와 같은 여러 이점이 있다. 일대다 단방향 매핑은 다른 테이블의 fk를 관리하기 때문에 다른 테이블에 update쿼리가 나가는건 어쩔 수 없다. 이게 싫다면 양방향으로 하는 것도 필요하다면 가능하다. 

자 그럼 정리.
엔티티 타입 vs 값 타입 이걸 혼동하지 말자.
엔티티 타입은 식별자가 있고, 생명주기를 자신이 관리한다. 공유되어야 한다(?) -> 참조 값을 넘긴다 라는 말 같다.
값 타입은 식별자가 없고, 생명주기를 엔티티에 의존한다. 공유되면 안된다. 

식별자가 필요하거나, 지속해서 값을 추적 및 변경해야 한다면 그건 엔티티 타입이다.